### PR TITLE
Extra: Run the build steps in parallel

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,6 +1,7 @@
 steps:
   # reservations
   - name: 'gcr.io/cloud-builders/docker'
+    id: 'build-reservations'
     args:
       [
         'build',
@@ -10,15 +11,20 @@ steps:
         'apps/reservations/Dockerfile',
         '.',
       ]
+    waitFor: ['-'] # The '-' indicates that this step begins immediately.
+
   - name: 'gcr.io/cloud-builders/docker'
+    id: 'push-reservations'
     args:
       [
         'push',
         'us-east4-docker.pkg.dev/disco-skyline-416915/reservations/production',
       ]
+    waitFor: ['build-reservations']
 
   # auth
   - name: 'gcr.io/cloud-builders/docker'
+    id: 'build-auth'
     args:
       [
         'build',
@@ -28,12 +34,17 @@ steps:
         'apps/auth/Dockerfile',
         '.',
       ]
+    waitFor: ['-'] # The '-' indicates that this step begins immediately.
+
   - name: 'gcr.io/cloud-builders/docker'
+    id: 'push-auth'
     args:
       ['push', 'us-east4-docker.pkg.dev/disco-skyline-416915/auth/production']
+    waitFor: ['build-auth']
 
   # payments
   - name: 'gcr.io/cloud-builders/docker'
+    id: 'build-payments'
     args:
       [
         'build',
@@ -43,15 +54,20 @@ steps:
         'apps/payments/Dockerfile',
         '.',
       ]
+    waitFor: ['-'] # The '-' indicates that this step begins immediately.
+
   - name: 'gcr.io/cloud-builders/docker'
+    id: 'push-payments'
     args:
       [
         'push',
         'us-east4-docker.pkg.dev/disco-skyline-416915/payments/production',
       ]
+    waitFor: ['build-payments']
 
   # notifications
   - name: 'gcr.io/cloud-builders/docker'
+    id: 'build-notifications'
     args:
       [
         'build',
@@ -61,9 +77,13 @@ steps:
         'apps/notifications/Dockerfile',
         '.',
       ]
+    waitFor: ['-'] # The '-' indicates that this step begins immediately.
+
   - name: 'gcr.io/cloud-builders/docker'
+    id: 'push-notifications'
     args:
       [
         'push',
         'us-east4-docker.pkg.dev/disco-skyline-416915/notifications/production',
       ]
+    waitFor: ['build-notifications']


### PR DESCRIPTION
I added a tip to the course https://www.udemy.com/course/nestjs-microservices-build-deploy-a-scaleable-backend/learn/lecture/37166784#questions/21485772.

The cloud build file we created in the course is running the steps synchronously. Modifying the steps to be run in parallel shaves over a minute off the build, based on what I am seeing in my setup. For the purposes of this course, this is fine, but in a production environment, reducing build times is important. I've done similar build modifications in CircleCI and I wanted to learn how to do it in Google Cloud Build. The documentation for this feature can be found [here](https://cloud.google.com/build/docs/configuring-builds/configure-build-step-order).

<img width="1057" alt="Screenshot 2024-03-12 at 4 53 41 PM" src="https://github.com/nicholeuf/udemy-sleepr/assets/16197461/6d703d09-7dcc-493d-a4ed-99340eeaacfb">


