### PR TITLE
Section 6 Con't: Production deployment

### DIFF
--- a/apps/auth/src/auth.module.ts
+++ b/apps/auth/src/auth.module.ts
@@ -3,7 +3,7 @@ import { Module } from '@nestjs/common';
 import { JwtModule } from '@nestjs/jwt';
 import { ConfigModule, ConfigService } from '@nestjs/config';
 
-import { LoggerModule } from '@app/common';
+import { HealthModule, LoggerModule } from '@app/common';
 import { LocalStrategy } from './strategies/local.strategy';
 import { AuthController } from './auth.controller';
 import { AuthService } from './auth.service';
@@ -33,6 +33,7 @@ import { JwtStrategy } from './strategies/jwt.strategy';
       }),
       inject: [ConfigService],
     }),
+    HealthModule,
   ],
   controllers: [AuthController],
   providers: [AuthService, LocalStrategy, JwtStrategy],

--- a/apps/auth/src/users/users.module.ts
+++ b/apps/auth/src/users/users.module.ts
@@ -2,10 +2,7 @@ import { Module } from '@nestjs/common';
 import { UsersController } from './users.controller';
 import { UsersService } from './users.service';
 import { DatabaseModule } from '@app/common';
-import {
-  UserDocument,
-  UserSchema,
-} from '../../../../libs/common/src/models/user.schema';
+import { UserDocument, UserSchema } from '@app/common';
 import { UsersRepository } from './users.reponsitory';
 
 @Module({

--- a/apps/reservations/src/reservations.module.ts
+++ b/apps/reservations/src/reservations.module.ts
@@ -7,6 +7,7 @@ import {
   LoggerModule,
   AUTH_SERVICE,
   PAYMENTS_SERVICE,
+  HealthModule,
 } from '@app/common';
 import { ReservationsRepository } from './reservations.repository';
 import {
@@ -60,6 +61,7 @@ import { ClientsModule, Transport } from '@nestjs/microservices';
         inject: [ConfigService],
       },
     ]),
+    HealthModule,
   ],
 
   controllers: [ReservationsController],

--- a/k8s/README.md
+++ b/k8s/README.md
@@ -28,8 +28,9 @@ Before getting started, you should have the following installed
 
 ### Add secrets to kubernetes cluster
 
-1. Add google secrets as a kubernetes by typing `kubectl create secret generic google --from-literal=clientSecret=<CLIENT_SECRET> --from-literal=refreshToken=<REFRESH_TOKEN`
-2. Add smtp email as a kubernetes secret by typing `kubectl create secret generic smtp --from-literal=user=<SMTP_USER>`
+1. Add google secrets by typing `kubectl create secret generic google --from-literal=clientSecret=<CLIENT_SECRET> --from-literal=refreshToken=<REFRESH_TOKEN`
+2. Add smtp email by typing `kubectl create secret generic smtp --from-literal=user=<SMTP_USER>`
+3. Add stripe api key by typing `kubectl create secret generic stripe --from-literal=apiKey=<STRIPE_API_KEY>`
 
 ### Using sleepr
 

--- a/k8s/README.md
+++ b/k8s/README.md
@@ -31,6 +31,7 @@ Before getting started, you should have the following installed
 1. Add google secrets by typing `kubectl create secret generic google --from-literal=clientSecret=<CLIENT_SECRET> --from-literal=refreshToken=<REFRESH_TOKEN`
 2. Add smtp email by typing `kubectl create secret generic smtp --from-literal=user=<SMTP_USER>`
 3. Add stripe api key by typing `kubectl create secret generic stripe --from-literal=apiKey=<STRIPE_API_KEY>`
+4. Add JWT secret by typing `kubectl create secret generic jwt --from-literal=jwtSecret=<JWT_SECRET>`
 
 ### Using sleepr
 

--- a/k8s/README.md
+++ b/k8s/README.md
@@ -24,7 +24,7 @@ Before getting started, you should have the following installed
 ### Connect Atlas Mongodb
 
 1. [Get connection string from Atlas](https://www.mongodb.com/docs/guides/atlas/connection-string/)
-2. Add connection string as a kubernetes secret by typing `kubectl create secret generic mongodb --from-literal=<CONNECTION_STRING>`
+2. Add connection string as a kubernetes secret by typing `kubectl create secret generic mongodb --from-literal=connectionString='<CONNECTION_STRING>'`
 
 ### Add secrets to kubernetes cluster
 
@@ -32,6 +32,15 @@ Before getting started, you should have the following installed
 2. Add smtp email by typing `kubectl create secret generic smtp --from-literal=user=<SMTP_USER>`
 3. Add stripe api key by typing `kubectl create secret generic stripe --from-literal=apiKey=<STRIPE_API_KEY>`
 4. Add JWT secret by typing `kubectl create secret generic jwt --from-literal=jwtSecret=<JWT_SECRET>`
+
+### Editing secrets
+
+The following steps should be used for modifying the mongodb secret, from the [docs](/docs/tasks/configmap-secret/managing-secret-using-kubectl/#edit-secret):
+
+1. Type the following to base64 encode the connection string `echo -n CONNECTION_STRING' | base64`. Make note of the output for step 3 below.
+2. Type the following to edit the secret `kubectl edit secrets mongodb`. An editor will be displayed where the secret can be modified.
+3. Modify the connectionString value with single quotes around it, '<BASE64_CONNECTION_STRING>'
+4. Save the file.
 
 ### Using sleepr
 

--- a/k8s/README.md
+++ b/k8s/README.md
@@ -1,0 +1,39 @@
+## Kubernetes
+
+## Prerequisites
+
+Before getting started, you should have the following installed
+
+1. [Google Cloud CLI](https://cloud.google.com/sdk/docs/install-sdk)
+2. Docker Desktop
+
+## Setup
+
+### Setup Heml and Kubernetes
+
+1. [Install and turn on Kubernetes](https://docs.docker.com/desktop/kubernetes/#install-and-turn-on-kubernetes) from Docker Desktop
+2. [Install Helm](https://helm.sh/docs/intro/install/#helm)
+
+### Setup Google Cloud
+
+1. [Setup Google Cloud Service Account Username/Password](https://developers.google.com/workspace/guides/create-credentials#service-account)
+2. Download the credentials as JSON and cd into the directory where they are stored
+3. Save the credentials as a kubernetes secret by typing the following `kubectl create secret docker-registry gcr-json-key --docker-server=us-east4-docker.pkg.dev --docker-username=_json_key --docker-password="$(cat <FILE>)" --docker-email=<EMAIL>`
+4. Patch the service account by typing `kubectl patch serviceaccount default -p '{"imagePullSecrets": [{"name": "gcr-json-key"}]}'`
+
+### Connect Atlas Mongodb
+
+1. [Get connection string from Atlas](https://www.mongodb.com/docs/guides/atlas/connection-string/)
+2. Add connection string as a kubernetes secret by typing `kubectl create secret generic mongodb --from-literal=<CONNECTION_STRING>`
+
+### Add secrets to kubernetes cluster
+
+1. Add google secrets as a kubernetes by typing `kubectl create secret generic google --from-literal=clientSecret=<CLIENT_SECRET> --from-literal=refreshToken=<REFRESH_TOKEN`
+2. Add smtp email as a kubernetes secret by typing `kubectl create secret generic smtp --from-literal=user=<SMTP_USER>`
+
+### Using sleepr
+
+- To install sleepr, type the following `helm install sleepr ./sleepr`. This should only need to be done once.
+- To upgrade sleepr, type the following `helm upgrade sleepr ./sleepr`
+- To view the pods, type the following: `kubectl get po`
+- To view the services, type the following: `kubectl get svc`

--- a/k8s/sleepr/.helmignore
+++ b/k8s/sleepr/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/k8s/sleepr/Chart.yaml
+++ b/k8s/sleepr/Chart.yaml
@@ -1,0 +1,24 @@
+apiVersion: v2
+name: sleepr
+description: A Helm chart for Kubernetes
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.1.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+appVersion: "1.16.0"

--- a/k8s/sleepr/templates/auth/deployment.yaml
+++ b/k8s/sleepr/templates/auth/deployment.yaml
@@ -1,0 +1,25 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: auth
+  name: auth
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: auth
+  template:
+    metadata:
+      labels:
+        app: auth
+    spec:
+      containers:
+        - image: us-east4-docker.pkg.dev/disco-skyline-416915/auth/production
+          name: auth
+          env:
+            - name: MONGODB_URI
+              valueFrom:
+                secretKeyRef:
+                  name: mongodb
+                  key: connectionString

--- a/k8s/sleepr/templates/auth/deployment.yaml
+++ b/k8s/sleepr/templates/auth/deployment.yaml
@@ -23,3 +23,17 @@ spec:
                 secretKeyRef:
                   name: mongodb
                   key: connectionString
+            - name: JWT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: jwt
+                  key: jwtSecret
+            - name: JWT_EXPIRATION
+              value: '3600'
+            - name: HTTP_PORT
+              value: '3003'
+            - name: TCP_PORT
+              value: '3002'
+          ports:
+            - containerPort: 3002
+            - containerPort: 3003

--- a/k8s/sleepr/templates/auth/service-http.yaml
+++ b/k8s/sleepr/templates/auth/service-http.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: auth
+  name: auth-http
+spec:
+  ports:
+    - name: 'http'
+      port: 3003
+      protocol: TCP
+      targetPort: 3003
+  selector:
+    app: auth
+  type: NodePort

--- a/k8s/sleepr/templates/auth/service-tcp.yaml
+++ b/k8s/sleepr/templates/auth/service-tcp.yaml
@@ -3,17 +3,13 @@ kind: Service
 metadata:
   labels:
     app: auth
-  name: auth
+  name: auth-tcp
 spec:
   ports:
-    - name: '3002'
+    - name: 'tcp'
       port: 3002
       protocol: TCP
       targetPort: 3002
-    - name: '3003'
-      port: 3003
-      protocol: TCP
-      targetPort: 3003
   selector:
     app: auth
   type: ClusterIP

--- a/k8s/sleepr/templates/auth/service.yaml
+++ b/k8s/sleepr/templates/auth/service.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: auth
+  name: auth
+spec:
+  ports:
+    - name: '3002'
+      port: 3002
+      protocol: TCP
+      targetPort: 3002
+    - name: '3003'
+      port: 3003
+      protocol: TCP
+      targetPort: 3003
+  selector:
+    app: auth
+  type: ClusterIP

--- a/k8s/sleepr/templates/notifications/deployment.yaml
+++ b/k8s/sleepr/templates/notifications/deployment.yaml
@@ -1,0 +1,19 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: notifications
+  name: notifications
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: notifications
+  template:
+    metadata:
+      labels:
+        app: notifications
+    spec:
+      containers:
+        - image: us-east4-docker.pkg.dev/disco-skyline-416915/notifications/production
+          name: notifications

--- a/k8s/sleepr/templates/notifications/deployment.yaml
+++ b/k8s/sleepr/templates/notifications/deployment.yaml
@@ -17,3 +17,25 @@ spec:
       containers:
         - image: us-east4-docker.pkg.dev/disco-skyline-416915/notifications/production
           name: notifications
+          env:
+            - name: PORT
+              value: '3000'
+            - name: GOOGLE_OAUTH_CLIENT_ID
+              value: 27763717457-jv7jqmiepo3b375h06isn8ckp22hv81i.apps.googleusercontent.com
+            - name: SMTP_USER
+              valueFrom:
+                secretKeyRef:
+                  name: smtp
+                  key: user
+            - name: GOOGLE_OAUTH_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: google
+                  key: clientSecret
+            - name: GOOGLE_OAUTH_REFRESH_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: google
+                  key: refreshToken
+          ports:
+            - containerPort: 3000

--- a/k8s/sleepr/templates/notifications/service.yaml
+++ b/k8s/sleepr/templates/notifications/service.yaml
@@ -6,7 +6,7 @@ metadata:
   name: notifications
 spec:
   ports:
-    - name: '3000'
+    - name: 'tcp'
       port: 3000
       protocol: TCP
       targetPort: 3000

--- a/k8s/sleepr/templates/notifications/service.yaml
+++ b/k8s/sleepr/templates/notifications/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: notifications
+  name: notifications
+spec:
+  ports:
+    - name: '3000'
+      port: 3000
+      protocol: TCP
+      targetPort: 3000
+  selector:
+    app: notifications
+  type: ClusterIP

--- a/k8s/sleepr/templates/payments/deployment.yaml
+++ b/k8s/sleepr/templates/payments/deployment.yaml
@@ -17,3 +17,17 @@ spec:
       containers:
         - image: us-east4-docker.pkg.dev/disco-skyline-416915/payments/production
           name: payments
+          env:
+            - name: PORT
+              value: '3001'
+            - name: NOTIFICATIONS_HOST
+              value: notifications
+            - name: NOTIFICATIONS_PORT
+              value: '3000'
+            - name: STRIPE_SECRET_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: stripe
+                  key: apiKey
+          ports:
+            - containerPort: 3001

--- a/k8s/sleepr/templates/payments/deployment.yaml
+++ b/k8s/sleepr/templates/payments/deployment.yaml
@@ -1,0 +1,19 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: payments
+  name: payments
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: payments
+  template:
+    metadata:
+      labels:
+        app: payments
+    spec:
+      containers:
+        - image: us-east4-docker.pkg.dev/disco-skyline-416915/payments/production
+          name: payments

--- a/k8s/sleepr/templates/payments/service.yaml
+++ b/k8s/sleepr/templates/payments/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: payments
+  name: payments
+spec:
+  ports:
+    - name: '3001'
+      port: 3001
+      protocol: TCP
+      targetPort: 3001
+  selector:
+    app: payments
+  type: ClusterIP

--- a/k8s/sleepr/templates/payments/service.yaml
+++ b/k8s/sleepr/templates/payments/service.yaml
@@ -6,7 +6,7 @@ metadata:
   name: payments
 spec:
   ports:
-    - name: '3001'
+    - name: 'tcp'
       port: 3001
       protocol: TCP
       targetPort: 3001

--- a/k8s/sleepr/templates/reservations/deployment.yaml
+++ b/k8s/sleepr/templates/reservations/deployment.yaml
@@ -26,7 +26,7 @@ spec:
             - name: PORT
               value: '3004'
             - name: AUTH_HOST
-              value: auth
+              value: auth-tcp
             - name: AUTH_PORT
               value: '3002'
             - name: PAYMENTS_HOST

--- a/k8s/sleepr/templates/reservations/deployment.yaml
+++ b/k8s/sleepr/templates/reservations/deployment.yaml
@@ -23,3 +23,15 @@ spec:
                 secretKeyRef:
                   name: mongodb
                   key: connectionString
+            - name: PORT
+              value: '3004'
+            - name: AUTH_HOST
+              value: auth
+            - name: AUTH_PORT
+              value: '3002'
+            - name: PAYMENTS_HOST
+              value: payments
+            - name: PAYMENTS_PORT
+              value: '3001'
+          ports:
+            - containerPort: 3004

--- a/k8s/sleepr/templates/reservations/deployment.yaml
+++ b/k8s/sleepr/templates/reservations/deployment.yaml
@@ -1,0 +1,25 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: reservations
+  name: reservations
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: reservations
+  template:
+    metadata:
+      labels:
+        app: reservations
+    spec:
+      containers:
+        - image: us-east4-docker.pkg.dev/disco-skyline-416915/reservations/production
+          name: reservations
+          env:
+            - name: MONGODB_URI
+              valueFrom:
+                secretKeyRef:
+                  name: mongodb
+                  key: connectionString

--- a/k8s/sleepr/templates/reservations/service.yaml
+++ b/k8s/sleepr/templates/reservations/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: reservations
+  name: reservations
+spec:
+  ports:
+    - name: 'http'
+      port: 3004
+      protocol: TCP
+      targetPort: 3004
+  selector:
+    app: reservations
+  type: NodePort

--- a/libs/common/src/health/health.controller.ts
+++ b/libs/common/src/health/health.controller.ts
@@ -1,0 +1,9 @@
+import { Controller, Get } from '@nestjs/common';
+
+@Controller('/')
+export class HealthController {
+  @Get()
+  health() {
+    return true;
+  }
+}

--- a/libs/common/src/health/health.module.ts
+++ b/libs/common/src/health/health.module.ts
@@ -1,0 +1,7 @@
+import { Module } from '@nestjs/common';
+import { HealthController } from './health.controller';
+
+@Module({
+  controllers: [HealthController],
+})
+export class HealthModule {}

--- a/libs/common/src/health/index.ts
+++ b/libs/common/src/health/index.ts
@@ -1,0 +1,2 @@
+export * from './health.controller';
+export * from './health.module';

--- a/libs/common/src/index.ts
+++ b/libs/common/src/index.ts
@@ -5,3 +5,4 @@ export * from './constants';
 export * from './decorators';
 export * from './dto';
 export * from './models';
+export * from './health';


### PR DESCRIPTION
Note: The first part of section 6 had to be merged to master in order to test the Google Cloud CI flow on pushes to master. This PR includes the remaining work completed in the section.

- [x] Add a README with instructions on how to set up and use helm and kubernetes.
- [x] Add Helm Chart and save Atlas connection string to kubernetes. Apply to reservations and auth app deployment file.
- [x] Set up notifications app and verify it is running in kubernetes.
- [x] Set up payments app and verify it is running in kubernetes.
- [x] Debug issue with the auth application connecting to Atlas. The issue was that I was missing single quotes around the connection string when saving the secret to kubernetes. See the [udemy question](https://www.udemy.com/course/nestjs-microservices-build-deploy-a-scaleable-backend/learn/lecture/37166590#questions/20668512) where I added a comment about how I solved the issue. 
- [x] Add remaining variables to kubernetes
- [x] Add nodeports for auth and reservations
- [x] Add health module to reservations and auth